### PR TITLE
Update setup.py - upgraded PyTorch to 1.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ def get_install_requirements():
         "numpy",
         "scikit-learn",
         "trimesh==2.38.42",
-        "torch==0.4.1",
+        "torch==1.11.0",
         "torchvision==0.1.8",
         "progress==1.4",
         "cython",


### PR DESCRIPTION
Hello there! Thanks a lot for your amazing work! I was just using your repo which is being used in [Learnable Earthparser](https://github.com/romainloiseau/LearnableEarthParser). I found that the PyTorch version required by the repo is `torch==0.4.1` which is very old and not supported on many systems. I installed your Python module with a modified `setup.py` requiring `torch==1.11.0` instead. The modified module seems to have installed successfully on my machine.

I request you to kindly review the PyTorch dependency version to a newer version (`1.11.0` seems to work for me) so that its easier for people to use.

Thanks again.
Best,
Aakash Singh Bais